### PR TITLE
Add newing of variables used within various line labels

### DIFF
--- a/Routines/%ut.m
+++ b/Routines/%ut.m
@@ -55,7 +55,7 @@ EN1(%utROU,%utLIST)	;
 	; ZEXCEPT: %ut  -- NEWED IN EN
 	; ZEXCEPT: GetCPUTime,Process -- parts of Cache method names
 	; ZEXCEPT: IOM - if present margin width defined by Kernel
-	N %utERRL,%utK,%utI,%utJ,%utSTRT,%utONLY,%utROU1
+	N %utERRL,%utK,%utI,%utJ,%utSTRT,%utONLY,%utROU1,I
 	; ZEXCEPT: %utVERB   -- ARGUMENT TO EN
 	I '+$G(%utVERB) S %utVERB=0
 	;

--- a/Routines/%ut1.m
+++ b/Routines/%ut1.m
@@ -32,7 +32,7 @@ CHEKTEST(%utROU,%ut,%utUETRY,FLAG)	; Collect Test list.
 	S %ut("ENTN")=0 ; Number of test, sub to %utUETRY.
 	;
 	; This stanza and everything below is for collecting @TEST.
-	N I,LIST
+	N I,J,LIST
 	S FLAG=$G(FLAG,0)
 	S I=$L($T(@(U_%utROU))) I I<0 Q "-1^Invalid Routine Name"
 	D NEWSTYLE(.LIST,%utROU)


### PR DESCRIPTION
Two variables were missed in the NEW command that cause the variables
to leak out of the unit test framework and be left in the stack